### PR TITLE
Add LSTM and Transformer models

### DIFF
--- a/ssm/model/__init__.py
+++ b/ssm/model/__init__.py
@@ -2,10 +2,13 @@
 Module for the definition of the models.
 """
 
-__all__ = ["S4", "S6", "Mamba", "GatedMLP", "H3"]
+__all__ = ["S4", "S6", "Mamba", "GatedMLP", "H3", "Transformer", "LSTM"]
+
 
 from .s4 import S4
 from .s6 import S6
 from .h3 import H3
+from .lstm import LSTM
 from .mamba import Mamba
 from .gated_mlp import GatedMLP
+from .transformer import Transformer

--- a/ssm/model/lstm.py
+++ b/ssm/model/lstm.py
@@ -1,0 +1,49 @@
+import torch
+
+
+class LSTM(torch.nn.Module):
+    """
+    Wrapper class for torch.nn.LSTM.
+    """
+
+    def __init__(
+        self,
+        model_dim,
+        hidden_dim,
+        n_layers=2,
+        dropout=0.1,
+        **kwargs,
+    ):
+        """
+        Initialization of the LSTM model.
+
+        :param int model_dim: The input dimension.
+        :param int hidden_dim: The hidden state dimension.
+        :param int n_layers: Number of LSTM layers. Default is 2.
+        :param float dropout: Dropout rate. Default is 0.1.
+        :param dict kwargs: Additional keyword arguments used in the model.
+        """
+        super().__init__()
+
+        # Initialize the lstm model
+        self.lstm = torch.nn.LSTM(
+            input_size=model_dim,
+            hidden_size=hidden_dim,
+            num_layers=n_layers,
+            dropout=dropout,
+            batch_first=True,
+        )
+
+        # Linear layer to project the output to the input dimension
+        self.linear = torch.nn.Linear(hidden_dim, model_dim)
+
+    def forward(self, x):
+        """
+        Forward pass through the LSTM model.
+
+        :param torch.Tensor x: Input tensor (batch, seq length, dimension).
+        :return: Output tensor.
+        :rtype: torch.Tensor
+        """
+        output, _ = self.lstm(x)
+        return self.linear(output)

--- a/ssm/model/transformer.py
+++ b/ssm/model/transformer.py
@@ -3,7 +3,7 @@ import torch
 
 class Transformer(torch.nn.Module):
     """
-    Wrapper class for torch.nn.Transformer.
+    Wrapper class for torch.nn.TransformerEncoder.
     """
 
     def __init__(
@@ -11,8 +11,7 @@ class Transformer(torch.nn.Module):
         model_dim,
         hidden_dim,
         heads,
-        num_encoder_layers=2,
-        num_decoder_layers=2,
+        n_layers=2,
         dropout=0.1,
         activation="gelu",
         **kwargs,
@@ -23,8 +22,7 @@ class Transformer(torch.nn.Module):
         :param int model_dim: The input dimension.
         :param int hidden_dim: The hidden state dimension.
         :param int heads: The number of attention heads.
-        :param int num_encoder_layers: Number of encoder layers. Default is 2.
-        :param int num_decoder_layers: Number of decoder layers. Default is 2.
+        :param int n_layers: Number of encoder layers. Default is 2.
         :param float dropout: Dropout rate. Default is 0.1.
         :param str activation: The activation function. Must be one of
             `'gelu'` or `'relu'`. Default is `'gelu'`.
@@ -40,27 +38,28 @@ class Transformer(torch.nn.Module):
                 "The number of heads must be a divisor of the input dimension."
             )
 
-        # Initialize the transformer model
-        self.transformer = torch.nn.Transformer(
+        # Initialize the transformer encoder layer
+        self.encoder_layer = torch.nn.TransformerEncoderLayer(
             d_model=model_dim,
             nhead=heads,
-            num_encoder_layers=num_encoder_layers,
-            num_decoder_layers=num_decoder_layers,
             dim_feedforward=hidden_dim,
             dropout=dropout,
             activation=activation,
             batch_first=True,
         )
 
-    def forward(self, x, y, src_mask=None, tgt_mask=None):
+        self.transformer_encoder = torch.nn.TransformerEncoder(
+            encoder_layer=self.encoder_layer,
+            num_layers=n_layers,
+            norm=torch.nn.LayerNorm(model_dim),
+        )
+
+    def forward(self, x):
         """
         Forward pass through the Transformer model with optional masks.
 
         :param torch.Tensor x: Input tensor (batch, seq length, dimension).
-        :param torch.Tensor y: Target tensor (batch, seq length, dimension).
-        :param torch.Tensor src_mask: Source mask. Default is `None`.
-        :param torch.Tensor tgt_mask: Target mask. Default is `None`.
         :return: Output tensor.
         :rtype: torch.Tensor
         """
-        return self.transformer(x, y, src_mask=src_mask, tgt_mask=tgt_mask)
+        return self.transformer_encoder(x)

--- a/ssm/model/transformer.py
+++ b/ssm/model/transformer.py
@@ -1,0 +1,66 @@
+import torch
+
+
+class Transformer(torch.nn.Module):
+    """
+    Wrapper class for torch.nn.Transformer.
+    """
+
+    def __init__(
+        self,
+        model_dim,
+        hidden_dim,
+        heads,
+        num_encoder_layers=2,
+        num_decoder_layers=2,
+        dropout=0.1,
+        activation="gelu",
+        **kwargs,
+    ):
+        """
+        Initialization of the Transformer model.
+
+        :param int model_dim: The input dimension.
+        :param int hidden_dim: The hidden state dimension.
+        :param int heads: The number of attention heads.
+        :param int num_encoder_layers: Number of encoder layers. Default is 2.
+        :param int num_decoder_layers: Number of decoder layers. Default is 2.
+        :param float dropout: Dropout rate. Default is 0.1.
+        :param str activation: The activation function. Must be one of
+            `'gelu'` or `'relu'`. Default is `'gelu'`.
+        :param dict kwargs: Additional keyword arguments used in the model.
+        :raises ValueError: If the number of heads is not a divisor of the
+            input dimension.
+        """
+        super().__init__()
+
+        # Check if the number of heads is a divisor of the input dimension
+        if model_dim % heads != 0:
+            raise ValueError(
+                "The number of heads must be a divisor of the input dimension."
+            )
+
+        # Initialize the transformer model
+        self.transformer = torch.nn.Transformer(
+            d_model=model_dim,
+            nhead=heads,
+            num_encoder_layers=num_encoder_layers,
+            num_decoder_layers=num_decoder_layers,
+            dim_feedforward=hidden_dim,
+            dropout=dropout,
+            activation=activation,
+            batch_first=True,
+        )
+
+    def forward(self, x, y, src_mask=None, tgt_mask=None):
+        """
+        Forward pass through the Transformer model with optional masks.
+
+        :param torch.Tensor x: Input tensor (batch, seq length, dimension).
+        :param torch.Tensor y: Target tensor (batch, seq length, dimension).
+        :param torch.Tensor src_mask: Source mask. Default is `None`.
+        :param torch.Tensor tgt_mask: Target mask. Default is `None`.
+        :return: Output tensor.
+        :rtype: torch.Tensor
+        """
+        return self.transformer(x, y, src_mask=src_mask, tgt_mask=tgt_mask)

--- a/tests/test_lstm.py
+++ b/tests/test_lstm.py
@@ -1,0 +1,45 @@
+import torch
+from ssm.model import LSTM
+
+x = torch.randn(20, 25, 5)
+
+hid_dim = 10
+n_layers = 2
+dropout = 0.1
+
+
+def test_lstm_constructor():
+
+    LSTM(
+        model_dim=x.shape[2],
+        hidden_dim=hid_dim,
+        n_layers=n_layers,
+        dropout=dropout,
+    )
+
+
+def test_lstm_forward():
+
+    model = LSTM(
+        model_dim=x.shape[2],
+        hidden_dim=hid_dim,
+        n_layers=n_layers,
+        dropout=dropout,
+    )
+
+    y = model(x)
+    assert y.shape == x.shape
+
+
+def test_lstm_backward():
+
+    model = LSTM(
+        model_dim=x.shape[2],
+        hidden_dim=hid_dim,
+        n_layers=n_layers,
+        dropout=dropout,
+    )
+
+    y = model(x.requires_grad_())
+    _ = torch.mean(y).backward()
+    assert x.grad.shape == x.shape

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -1,0 +1,79 @@
+import pytest
+import torch
+from ssm.model import Transformer
+
+x = torch.randn(20, 25, 4)
+y = torch.randn(20, 25, 4)
+
+hid_dim = 10
+num_encoder_layers = 3
+num_decoder_layers = 3
+dropout = 0.1
+
+
+@pytest.mark.parametrize("heads", [2, 4])
+@pytest.mark.parametrize("activation", ["gelu", "relu"])
+def test_transformer_constructor(heads, activation):
+
+    Transformer(
+        model_dim=x.shape[2],
+        hidden_dim=hid_dim,
+        heads=heads,
+        num_encoder_layers=num_encoder_layers,
+        num_decoder_layers=num_decoder_layers,
+        dropout=dropout,
+        activation=activation,
+    )
+
+    # Invalid number of heads
+    with pytest.raises(ValueError):
+        Transformer(
+            model_dim=x.shape[2],
+            hidden_dim=hid_dim,
+            heads=3,
+            num_encoder_layers=num_encoder_layers,
+            num_decoder_layers=num_decoder_layers,
+            dropout=dropout,
+            activation=activation,
+        )
+
+
+@pytest.mark.parametrize("heads", [2, 4])
+@pytest.mark.parametrize("src_mask", [None, torch.ones(25, 25)])
+@pytest.mark.parametrize("tgt_mask", [None, torch.ones(25, 25)])
+@pytest.mark.parametrize("activation", ["gelu", "relu"])
+def test_transformer_forward(heads, src_mask, tgt_mask, activation):
+
+    model = Transformer(
+        model_dim=x.shape[2],
+        hidden_dim=hid_dim,
+        heads=heads,
+        num_encoder_layers=num_encoder_layers,
+        num_decoder_layers=num_decoder_layers,
+        dropout=dropout,
+        activation=activation,
+    )
+
+    output_ = model(x, y, src_mask=src_mask, tgt_mask=tgt_mask)
+    assert output_.shape == x.shape
+
+
+@pytest.mark.parametrize("heads", [2, 4])
+@pytest.mark.parametrize("src_mask", [None, torch.ones(25, 25)])
+@pytest.mark.parametrize("tgt_mask", [None, torch.ones(25, 25)])
+@pytest.mark.parametrize("activation", ["gelu", "relu"])
+def test_transformer_backward(heads, src_mask, tgt_mask, activation):
+
+    model = Transformer(
+        model_dim=x.shape[2],
+        hidden_dim=hid_dim,
+        heads=heads,
+        num_encoder_layers=num_encoder_layers,
+        num_decoder_layers=num_decoder_layers,
+        dropout=dropout,
+        activation=activation,
+    )
+
+    output_ = model(x.requires_grad_(), y, src_mask=src_mask, tgt_mask=tgt_mask)
+    _ = torch.mean(output_).backward()
+    assert x.grad.shape == x.shape

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -3,11 +3,9 @@ import torch
 from ssm.model import Transformer
 
 x = torch.randn(20, 25, 4)
-y = torch.randn(20, 25, 4)
 
 hid_dim = 10
-num_encoder_layers = 3
-num_decoder_layers = 3
+n_layers = 2
 dropout = 0.1
 
 
@@ -19,8 +17,7 @@ def test_transformer_constructor(heads, activation):
         model_dim=x.shape[2],
         hidden_dim=hid_dim,
         heads=heads,
-        num_encoder_layers=num_encoder_layers,
-        num_decoder_layers=num_decoder_layers,
+        n_layers=n_layers,
         dropout=dropout,
         activation=activation,
     )
@@ -31,49 +28,42 @@ def test_transformer_constructor(heads, activation):
             model_dim=x.shape[2],
             hidden_dim=hid_dim,
             heads=3,
-            num_encoder_layers=num_encoder_layers,
-            num_decoder_layers=num_decoder_layers,
+            n_layers=n_layers,
             dropout=dropout,
             activation=activation,
         )
 
 
 @pytest.mark.parametrize("heads", [2, 4])
-@pytest.mark.parametrize("src_mask", [None, torch.ones(25, 25)])
-@pytest.mark.parametrize("tgt_mask", [None, torch.ones(25, 25)])
 @pytest.mark.parametrize("activation", ["gelu", "relu"])
-def test_transformer_forward(heads, src_mask, tgt_mask, activation):
+def test_transformer_forward(heads, activation):
 
     model = Transformer(
         model_dim=x.shape[2],
         hidden_dim=hid_dim,
         heads=heads,
-        num_encoder_layers=num_encoder_layers,
-        num_decoder_layers=num_decoder_layers,
+        n_layers=n_layers,
         dropout=dropout,
         activation=activation,
     )
 
-    output_ = model(x, y, src_mask=src_mask, tgt_mask=tgt_mask)
-    assert output_.shape == x.shape
+    y = model(x)
+    assert y.shape == x.shape
 
 
 @pytest.mark.parametrize("heads", [2, 4])
-@pytest.mark.parametrize("src_mask", [None, torch.ones(25, 25)])
-@pytest.mark.parametrize("tgt_mask", [None, torch.ones(25, 25)])
 @pytest.mark.parametrize("activation", ["gelu", "relu"])
-def test_transformer_backward(heads, src_mask, tgt_mask, activation):
+def test_transformer_backward(heads, activation):
 
     model = Transformer(
         model_dim=x.shape[2],
         hidden_dim=hid_dim,
         heads=heads,
-        num_encoder_layers=num_encoder_layers,
-        num_decoder_layers=num_decoder_layers,
+        n_layers=n_layers,
         dropout=dropout,
         activation=activation,
     )
 
-    output_ = model(x.requires_grad_(), y, src_mask=src_mask, tgt_mask=tgt_mask)
-    _ = torch.mean(output_).backward()
+    y = model(x.requires_grad_())
+    _ = torch.mean(y).backward()
     assert x.grad.shape == x.shape


### PR DESCRIPTION
In this PR I added both `LSTM` and `Transfomer` models.

While the first one should be readily available for testing, the latter might require some changes to the pipeline, as the `forward` pass is structured to take as input both the input sequence and the target sequence.